### PR TITLE
reproduce the error

### DIFF
--- a/contracts/Test.sol
+++ b/contracts/Test.sol
@@ -1,9 +1,9 @@
-pragma solidity 0.8.6;
+pragma solidity 0.6.12;
 
 contract Test {
     uint256 public num = 0;
 
-    function setNum(uint256 value) external {
+    function setNum(uint256 value) external payable {
         num = value;
     }
 }

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -2,6 +2,6 @@ import "@nomiclabs/hardhat-ethers";
 
 module.exports = {
     solidity: {
-        version: "0.8.6",
+        version: "0.6.12",
     }
 };

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ const main = async () => {
 
     const num = 1337;
     console.log(`setting num ${num}`);
-    await test.setNum(num);
+    await test.setNum(num, {value: 5566});
 
     const newNum = await test.num();
     console.log(`num set to ${newNum}`);


### PR DESCRIPTION
- In our burn auction bidding call, the contract function is payable and we assign value
- In Solidity 0.8.6, the call works successfully. The call fails in 0.6.12

The error message

```
deploying test contract
Error: invalid BigNumber value (argument="value", value=null, code=INVALID_ARGUMENT, version=bignumber/5.3.0)
    at Logger.makeError (/Users/liangcc/projects/repos/ether-js-geth-issue/node_modules/@ethersproject/logger/lib/index.js:187:21)
    at Logger.throwError (/Users/liangcc/projects/repos/ether-js-geth-issue/node_modules/@ethersproject/logger/lib/index.js:196:20)
    at Logger.throwArgumentError (/Users/liangcc/projects/repos/ether-js-geth-issue/node_modules/@ethersproject/logger/lib/index.js:199:21)
    at Function.BigNumber.from (/Users/liangcc/projects/repos/ether-js-geth-issue/node_modules/@ethersproject/bignumber/lib/bignumber.js:241:23)
    at Formatter.bigNumber (/Users/liangcc/projects/repos/ether-js-geth-issue/node_modules/@ethersproject/providers/lib/formatter.js:137:38)
    at Function.Formatter.check (/Users/liangcc/projects/repos/ether-js-geth-issue/node_modules/@ethersproject/providers/lib/formatter.js:357:40)
    at Formatter.transactionResponse (/Users/liangcc/projects/repos/ether-js-geth-issue/node_modules/@ethersproject/providers/lib/formatter.js:267:32)
    at JsonRpcProvider.<anonymous> (/Users/liangcc/projects/repos/ether-js-geth-issue/node_modules/@ethersproject/providers/lib/base-provider.js:1628:65)
    at step (/Users/liangcc/projects/repos/ether-js-geth-issue/node_modules/@ethersproject/providers/lib/base-provider.js:48:23)
    at Object.next (/Users/liangcc/projects/repos/ether-js-geth-issue/node_modules/@ethersproject/providers/lib/base-provider.js:29:53) {
  reason: 'invalid BigNumber value',
  code: 'INVALID_ARGUMENT',
  argument: 'value',
  value: null,
  checkKey: 'gasPrice',
  checkValue: null,
  transactionHash: '0x86e11a4c53edc9a0da5cd44da53325cbafaf12a694dbc5ebffd27d24dbf4889d'
}

```